### PR TITLE
This fixes the problem with using args options for non default constructor. 

### DIFF
--- a/lib/Catalyst/Model/Adaptor/Base.pm
+++ b/lib/Catalyst/Model/Adaptor/Base.pm
@@ -37,7 +37,7 @@ sub prepare_arguments {
 
 sub mangle_arguments {
     my ($self, $args) = @_;
-    return $args;
+    return %$args;
 }
 
 1;


### PR DESCRIPTION
Fixing typo in mangle_arguments. Basing this on docs of lib/Catalyst/Model/Adaptor.pm
