### PR TITLE
NotMyApp::SomeClass may use MooseX::StrictConstructor

### DIFF
--- a/lib/Catalyst/Model/Adaptor/Base.pm
+++ b/lib/Catalyst/Model/Adaptor/Base.pm
@@ -22,9 +22,17 @@ sub _create_instance {
 
     my $constructor = $self->{constructor} || 'new';
     my $arg = $self->prepare_arguments($app, $rest);
+    $self->_handle_catalystmodel_args($arg);
     my $adapted_class = $self->{class};
 
     return $adapted_class->$constructor($self->mangle_arguments($arg));
+}
+
+sub _handle_catalystmodel_args {
+    my ($self, $arg) = @_;
+    my $keep_flag = $arg->{keep_catalystmodel_args}||0;
+    delete $arg->{keep_catalystmodel_args} ;
+    delete @{$arg}{'catalyst_component_name','class','args'} unless $keep_flag;
 }
 
 sub prepare_arguments {
@@ -61,6 +69,11 @@ Load the adapted class
 =head2 _create_instance
 
 Instantiate the adapted class
+
+=head2 _handle_catalystmodel_args
+
+Remove arguments which are default in Catalyst::Model but break things if our class
+uses MooseX::StrictConstructor
 
 =head2 prepare_arguments
 

--- a/t/lib/StrictTestApp.pm
+++ b/t/lib/StrictTestApp.pm
@@ -1,0 +1,13 @@
+package StrictTestApp;
+use strict;
+use warnings;
+
+use Catalyst;
+
+# Note __PACKAGE__->config->{'Model::NoArgs} -> not configured :)
+__PACKAGE__->config->{'Model::SomeClass'}{args}  = { foo => 'bar' };
+__PACKAGE__->config->{'Model::Factory'}{args}    = { foo => 'baz' };
+__PACKAGE__->config->{'Model::PerRequest'}{args} = { foo => 'quux'};
+__PACKAGE__->setup;
+
+1;

--- a/t/lib/StrictTestApp/Backend/InnerPackage.pm
+++ b/t/lib/StrictTestApp/Backend/InnerPackage.pm
@@ -1,0 +1,16 @@
+package StrictTestApp::Backend::InnerPackage;
+
+sub foo { 42 }
+
+package StrictTestApp::Backend::InnerPackage::Inner;
+
+use Moose;
+use MooseX::StrictConstructor;
+
+has 'okay' => (
+  is => 'ro',
+  default => 'Alright!',
+);
+
+no Moose;
+__PACKAGE__->meta->make_immutable;

--- a/t/lib/StrictTestApp/Backend/SomeClass.pm
+++ b/t/lib/StrictTestApp/Backend/SomeClass.pm
@@ -1,0 +1,21 @@
+package StrictTestApp::Backend::SomeClass;
+use Moose;
+use MooseX::StrictConstructor;
+
+my $id = 0;
+
+sub BUILD { $id++; }
+
+has _count => ( is => 'rw', isa => 'Int', default => 0 );
+sub count {
+    my $self = shift;
+    return $self->_count($self->_count+1);
+}
+
+sub id {
+    return $id;
+}
+
+has foo => ( is => 'ro' );
+
+1;

--- a/t/lib/StrictTestApp/BaseController/Adaptor.pm
+++ b/t/lib/StrictTestApp/BaseController/Adaptor.pm
@@ -1,0 +1,38 @@
+package StrictTestApp::BaseController::Adaptor;
+use strict;
+use warnings;
+use base 'Catalyst::Controller';
+
+sub model { shift->{model} }
+
+sub is_a :Path(isa) {
+    my ($self, $c) = @_;
+    $c->res->body(ref $c->model($self->model));
+}
+
+sub id :Local {
+    my ($self, $c) = @_;
+    $c->res->body($c->model($self->model)->id);
+}
+
+sub id_twice :Local {
+    my ($self, $c) = @_;
+    $c->res->body(join '|', map { $c->model($self->model)->id } 1..2);
+}
+
+sub count :Local {
+    my ($self, $c) = @_;
+    $c->res->body($c->model($self->model)->count);
+}
+
+sub count_twice :Local {
+    my ($self, $c) = @_;
+    $c->res->body(join '|', map { $c->model($self->model)->count } 1..2);
+}
+
+sub foo :Local {
+    my ($self, $c) = @_;
+    $c->res->body($c->model($self->model)->foo);
+}
+
+1;

--- a/t/lib/StrictTestApp/Controller/Adaptor.pm
+++ b/t/lib/StrictTestApp/Controller/Adaptor.pm
@@ -1,0 +1,9 @@
+package StrictTestApp::Controller::Adaptor;
+use strict;
+use warnings;
+
+use base 'StrictTestApp::BaseController::Adaptor';
+
+__PACKAGE__->config( model => 'SomeClass' );
+
+1;

--- a/t/lib/StrictTestApp/Controller/Factory.pm
+++ b/t/lib/StrictTestApp/Controller/Factory.pm
@@ -1,0 +1,14 @@
+package StrictTestApp::Controller::Factory;
+use strict;
+use warnings;
+
+use base 'StrictTestApp::BaseController::Adaptor';
+
+__PACKAGE__->config( model => 'Factory' );
+
+sub foo :Local {
+    my ($self, $c) = @_;
+    $c->res->body($c->model($self->model, foo => 'factory')->foo);
+}
+
+1;

--- a/t/lib/StrictTestApp/Controller/InnerPackage.pm
+++ b/t/lib/StrictTestApp/Controller/InnerPackage.pm
@@ -1,0 +1,9 @@
+package StrictTestApp::Controller::InnerPackage;
+use strict;
+use warnings;
+
+use base 'StrictTestApp::BaseController::Adaptor';
+
+__PACKAGE__->config( model => 'InnerPackage' );
+
+1;

--- a/t/lib/StrictTestApp/Controller/PerRequest.pm
+++ b/t/lib/StrictTestApp/Controller/PerRequest.pm
@@ -1,0 +1,14 @@
+package StrictTestApp::Controller::PerRequest;
+use strict;
+use warnings;
+
+use base 'StrictTestApp::BaseController::Adaptor';
+
+__PACKAGE__->config( model => 'PerRequest' );
+
+sub foo :Local {
+    my ($self, $c) = @_;
+    $c->res->body($c->model($self->model, { foo => 'perrequest' })->foo);
+}
+
+1;

--- a/t/lib/StrictTestApp/Controller/Root.pm
+++ b/t/lib/StrictTestApp/Controller/Root.pm
@@ -1,0 +1,12 @@
+package StrictTestApp::Controller::Root;
+use strict;
+use warnings;
+
+__PACKAGE__->config(namespace => q{});
+
+use base 'Catalyst::Controller';
+
+# your actions replace this one
+sub main :Path { $_[1]->res->body('<h1>It works</h1>') }
+
+1;

--- a/t/lib/StrictTestApp/Model/Factory.pm
+++ b/t/lib/StrictTestApp/Model/Factory.pm
@@ -1,0 +1,9 @@
+package StrictTestApp::Model::Factory;
+use strict;
+use warnings;
+
+use base 'Catalyst::Model::Factory';
+
+__PACKAGE__->config( class => 'StrictTestApp::Backend::SomeClass' );
+
+1;

--- a/t/lib/StrictTestApp/Model/InnerPackage.pm
+++ b/t/lib/StrictTestApp/Model/InnerPackage.pm
@@ -1,0 +1,11 @@
+package StrictTestApp::Model::InnerPackage;
+use strict;
+use warnings;
+
+use StrictTestApp::Backend::InnerPackage;
+
+use base 'Catalyst::Model::Adaptor';
+
+__PACKAGE__->config( class => 'StrictTestApp::Backend::InnerPackage::Inner' );
+
+1;

--- a/t/lib/StrictTestApp/Model/NoArgs.pm
+++ b/t/lib/StrictTestApp/Model/NoArgs.pm
@@ -1,0 +1,9 @@
+package StrictTestApp::Model::NoArgs;
+use strict;
+use warnings;
+
+use base 'Catalyst::Model::Adaptor';
+
+__PACKAGE__->config( class => 'StrictTestApp::Backend::SomeClass' );
+
+1;

--- a/t/lib/StrictTestApp/Model/PerRequest.pm
+++ b/t/lib/StrictTestApp/Model/PerRequest.pm
@@ -1,0 +1,9 @@
+package StrictTestApp::Model::PerRequest;
+use strict;
+use warnings;
+
+use base 'Catalyst::Model::Factory::PerRequest';
+
+__PACKAGE__->config( class => 'StrictTestApp::Backend::SomeClass' );
+
+1;

--- a/t/lib/StrictTestApp/Model/SomeClass.pm
+++ b/t/lib/StrictTestApp/Model/SomeClass.pm
@@ -1,0 +1,9 @@
+package StrictTestApp::Model::SomeClass;
+use strict;
+use warnings;
+
+use base 'Catalyst::Model::Adaptor';
+
+__PACKAGE__->config( class => 'StrictTestApp::Backend::SomeClass' );
+
+1;

--- a/t/strict-live-test.t
+++ b/t/strict-live-test.t
@@ -1,0 +1,145 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+use Test::More;
+
+# setup library path
+use FindBin qw($Bin);
+use lib "$Bin/lib";
+
+BEGIN {
+    plan skip_all => 'this test needs Test::WWW::Mechanize::Catalyst'
+      unless eval "require Test::WWW::Mechanize::Catalyst";
+    plan skip_all => 'this test needs Moose'
+      unless eval "require Moose";
+    plan skip_all => 'this test needs MooseX::StrictConstructor'
+      unless eval "require MooseX::StrictConstructor";
+
+    plan tests => 49;
+}
+
+# make sure testapp works
+use ok 'StrictTestApp';
+
+# a live test against StrictTestApp, the test application
+use Test::WWW::Mechanize::Catalyst 'StrictTestApp';
+my $mech = Test::WWW::Mechanize::Catalyst->new;
+$mech->get_ok('http://localhost/', 'get main page');
+$mech->content_like(qr/it works/i, 'see if it has our text');
+
+# adaptor
+{
+    $mech->get_ok('http://localhost/adaptor/isa', 'get the class name');
+    $mech->content_like(qr/^StrictTestApp::Backend::SomeClass$/,
+                        'adapted class is itself');
+}
+
+{
+    $mech->get_ok('http://localhost/adaptor/id_twice', 'get id_twice');
+    my ($a, $b) = split /\|/, $mech->content;
+    is $a, $b, 'same instance both times';
+
+    $mech->get_ok('http://localhost/adaptor/id', 'get id');
+    is $mech->content, $a, 'same instance for different request';
+}
+
+{
+    $mech->get_ok('http://localhost/adaptor/foo', 'get foo');
+    $mech->content_like(qr/^bar$/, 'got foo = bar');
+}
+
+{
+    $mech->get_ok('http://localhost/adaptor/count', 'get count');
+    my $a = $mech->content;
+    $mech->get_ok('http://localhost/adaptor/count', 'get count (+1)');
+    my $b = $mech->content;
+
+    is $b, $a+1, 'same instance across requests';
+}
+{
+    $mech->get_ok('http://localhost/adaptor/count_twice', 'get count_twice');
+    my ($a, $b) = split/\|/, $mech->content;
+    is $a, 3, '3 count for a';
+    is $b, 4, '4 count for b';
+}
+
+# factory
+{
+    $mech->get_ok('http://localhost/factory/isa', 'get the class name');
+    $mech->content_like(qr/^StrictTestApp::Backend::SomeClass$/,
+                        'adapted class is itself');
+}
+
+{
+    $mech->get_ok('http://localhost/factory/id_twice', 'get id_twice');
+    my ($a, $b) = split /\|/, $mech->content;
+    is $b, $a+1, 'different instance both times';
+
+    $mech->get_ok('http://localhost/factory/id', 'get id');
+    is $mech->content, $b+1, 'same instance for different request too';
+
+}
+
+{
+    $mech->get_ok('http://localhost/factory/foo', 'get foo');
+    $mech->content_like(qr/^factory$/, 'got foo = factory');
+}
+{
+    $mech->get_ok('http://localhost/factory/count', 'get count');
+    my $a = $mech->content;
+    $mech->get_ok('http://localhost/factory/count', 'get count (+1)');
+    my $b = $mech->content;
+
+    is $a, 1, '1st request for a';
+    is $b, 1, '1st request for b too';
+}
+{
+    $mech->get_ok('http://localhost/factory/count_twice', 'get count_twice');
+    my ($a, $b) = split/\|/, $mech->content;
+    is $a, 1, '1 count for a';
+    is $b, 1, '1 count for b too';
+}
+
+# per_request
+{
+    $mech->get_ok('http://localhost/perrequest/isa', 'get the class name');
+    $mech->content_like(qr/^StrictTestApp::Backend::SomeClass$/,
+                        'adapted class is itself');
+}
+
+{
+    $mech->get_ok('http://localhost/perrequest/id_twice', 'get id_twice');
+    my ($a, $b) = split /\|/, $mech->content;
+    is $a, $b, 'same instance both times';
+
+    $mech->get_ok('http://localhost/perrequest/id', 'get id');
+    is $mech->content, $a+1, 'different instance for different request';
+}
+
+{
+    $mech->get_ok('http://localhost/perrequest/foo', 'get foo');
+    $mech->content_like(qr/^perrequest$/, 'got foo = perrequest');
+}
+{
+    $mech->get_ok('http://localhost/perrequest/count', 'get count');
+    my $a = $mech->content;
+    $mech->get_ok('http://localhost/perrequest/count', 'get count (+1)');
+    my $b = $mech->content;
+
+    is $a, 1, '1st request for a';
+    is $b, 1, '1st request for b too';
+}
+{
+    $mech->get_ok('http://localhost/perrequest/count_twice', 'get count_twice');
+    my ($a, $b) = split/\|/, $mech->content;
+    is $a, 1, '1 count for a';
+    is $b, 2, '2 count for b';
+}
+
+# inner package
+{
+    $mech->get_ok('http://localhost/innerpackage/isa', 'get the class name');
+    $mech->content_like(qr/^StrictTestApp::Backend::InnerPackage::Inner$/,
+                        'got the right package for inner class');
+}


### PR DESCRIPTION
Hi, 

Catalyst::Model::Adaptor causes an error on an external ModelClass which uses
MooseX::Contstructor, because catalyst default model has some extra args it passes to the
constructor.

see: http://paste.scsys.co.uk/202967

I had a short discussion with mst at this topic on irc. He gave me the patch
to remove extra arguments with a switch called strip_arguments, where the relevant args should 
be listet. 
**PACKAGE**->config(class => 'Blah', strip_arguments => [ qw(catalyst_component_name class) ]);

But as the Docs say there are no additional arguments handed over to external model class
it should not break things if one silently removes these extra arguments.

Please be patient this is my first patch :) 

git commit message:

Catalyst::Model::Adaptor did send some extra args to the constructor.
Documentation says this should not be the case. A Model using
MooseX::StrictConstructor will die due to this.

_handle_catalystmodel_args is added to lib/Catalyst/Model/Adaptor/Base.pm
to delete these extra args, injected by the Catalyst Model.

t/live-test.t is simply doubled and uses a Model with
MooseX::StrictConstructor. This is done with t/strict-live-test.t and
t/lib/StrictTestApp.pm.

t/strict-live-test.t will only run if MooseX::StrictConstructor is
installed.

Not nice is, that argumentes to be removed are hardcoded in
_handle_catalystmodel_args. But I don't know any other way to get those
dynamically.
